### PR TITLE
fix: disabling host check

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host 0.0.0.0",
+    "start": "ng serve --host 0.0.0.0 --disableHostCheck true",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"


### PR DESCRIPTION
### What does this PR do?:

Currently, the nodejs-angular starter project returns a `Invalid Host header` when validating the deployed devfile stack on CI.

Disabling the host check will allow a successful request by bypassing a security check that can result in a DNS rebinding attack.

ref: https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a

Without a different testing strategy for [registries](https://github.com/devfile/registry/tree/main/tests), host checking will need to be disabled. The risk is low since the dev-server is only up for ~2mins on CI and immediately destroyed once a 200 status is returned.

However, when consuming the starter project (using it for development), `--public-host` should be specified and would look something like this:

```bash
ng serve --host 0.0.0.0 --public-host myhost.com
```

### Which issue(s) this PR fixes:

Fixes https://github.com/devfile/api/issues/799